### PR TITLE
Yank-paset ページへのリンク が間違っていたので直しました

### DIFF
--- a/README.md
+++ b/README.md
@@ -520,7 +520,7 @@
 
 ### [Mapping](./mapping.md)
 
-### [Yank, Paste](./paste_yank.md)
+### [Yank, Paste](./yank_paste.md)
 
 ### Adding and subtracting
 


### PR DESCRIPTION
Yank, Paste のページへのリンクが `./paste_yank.md` になっていて リンク先が404だったので `yank_paste` に修正しました