### PR TITLE
Add

### DIFF
--- a/debugger_repl.md
+++ b/debugger_repl.md
@@ -94,6 +94,7 @@
 - [max607/nvim-terminal-send](https://github.com/max607/nvim-terminal-send) ![](https://img.shields.io/github/stars/max607/nvim-terminal-send) ![](https://img.shields.io/github/last-commit/max607/nvim-terminal-send) ![](https://img.shields.io/github/commit-activity/y/max607/nvim-terminal-send)
 - [Tyrannican/scratchy.nvim](https://github.com/Tyrannican/scratchy.nvim) ![](https://img.shields.io/github/stars/Tyrannican/scratchy.nvim) ![](https://img.shields.io/github/last-commit/Tyrannican/scratchy.nvim) ![](https://img.shields.io/github/commit-activity/y/Tyrannican/scratchy.nvim)
 - [walkingshamrock/runpad.nvim](https://github.com/walkingshamrock/runpad.nvim) ![](https://img.shields.io/github/stars/walkingshamrock/runpad.nvim) ![](https://img.shields.io/github/last-commit/walkingshamrock/runpad.nvim) ![](https://img.shields.io/github/commit-activity/y/walkingshamrock/runpad.nvim)
+- [fasterius/slime-peek.nvim](https://github.com/fasterius/slime-peek.nvim) ![](https://img.shields.io/github/stars/fasterius/slime-peek.nvim) ![](https://img.shields.io/github/last-commit/fasterius/slime-peek.nvim) ![](https://img.shields.io/github/commit-activity/y/fasterius/slime-peek.nvim)
 
 ### Refactoring,Debugging
 

--- a/documentation.md
+++ b/documentation.md
@@ -245,6 +245,7 @@
 - [SCJangra/table-nvim](https://github.com/SCJangra/table-nvim) ![](https://img.shields.io/github/stars/SCJangra/table-nvim) ![](https://img.shields.io/github/last-commit/SCJangra/table-nvim) ![](https://img.shields.io/github/commit-activity/y/SCJangra/table-nvim)
 - [nuhakala/nvim-simple-tables](https://github.com/nuhakala/nvim-simple-tables) ![](https://img.shields.io/github/stars/nuhakala/nvim-simple-tables) ![](https://img.shields.io/github/last-commit/nuhakala/nvim-simple-tables) ![](https://img.shields.io/github/commit-activity/y/nuhakala/nvim-simple-tables)
 - [bosha/md-table-navigation.nvim](https://github.com/bosha/md-table-navigation.nvim) ![](https://img.shields.io/github/stars/bosha/md-table-navigation.nvim) ![](https://img.shields.io/github/last-commit/bosha/md-table-navigation.nvim) ![](https://img.shields.io/github/commit-activity/y/bosha/md-table-navigation.nvim)
+- [timantipov/md-table-tidy.nvim](https://github.com/timantipov/md-table-tidy.nvim) ![](https://img.shields.io/github/stars/timantipov/md-table-tidy.nvim) ![](https://img.shields.io/github/last-commit/timantipov/md-table-tidy.nvim) ![](https://img.shields.io/github/commit-activity/y/timantipov/md-table-tidy.nvim)
 
 #### footnote
 

--- a/jump.md
+++ b/jump.md
@@ -39,6 +39,7 @@
 - [xlboy/node-edge-toggler.nvim](https://github.com/xlboy/node-edge-toggler.nvim) ![](https://img.shields.io/github/stars/xlboy/node-edge-toggler.nvim) ![](https://img.shields.io/github/last-commit/xlboy/node-edge-toggler.nvim) ![](https://img.shields.io/github/commit-activity/y/xlboy/node-edge-toggler.nvim)
 - [Mr-LLLLL/treesitter-outer](https://github.com/Mr-LLLLL/treesitter-outer) ![](https://img.shields.io/github/stars/Mr-LLLLL/treesitter-outer) ![](https://img.shields.io/github/last-commit/Mr-LLLLL/treesitter-outer) ![](https://img.shields.io/github/commit-activity/y/Mr-LLLLL/treesitter-outer)
 - [dsully/treesitter-jump.nvim](https://github.com/dsully/treesitter-jump.nvim) ![](https://img.shields.io/github/stars/dsully/treesitter-jump.nvim) ![](https://img.shields.io/github/last-commit/dsully/treesitter-jump.nvim) ![](https://img.shields.io/github/commit-activity/y/dsully/treesitter-jump.nvim)
+- [double-tilde/treesitter-tag-hop.nvim](https://github.com/double-tilde/treesitter-tag-hop.nvim) ![](https://img.shields.io/github/stars/double-tilde/treesitter-tag-hop.nvim) ![](https://img.shields.io/github/last-commit/double-tilde/treesitter-tag-hop.nvim) ![](https://img.shields.io/github/commit-activity/y/double-tilde/treesitter-tag-hop.nvim)
 
 #### File tracking
 

--- a/quickfix_location.md
+++ b/quickfix_location.md
@@ -32,6 +32,7 @@
 - [brunobmello25/persist-quickfix.nvim](https://github.com/brunobmello25/persist-quickfix.nvim) ![](https://img.shields.io/github/stars/brunobmello25/persist-quickfix.nvim) ![](https://img.shields.io/github/last-commit/brunobmello25/persist-quickfix.nvim) ![](https://img.shields.io/github/commit-activity/y/brunobmello25/persist-quickfix.nvim)
 - [whisperpine/quickfix-messages.nvim](https://github.com/whisperpine/quickfix-messages.nvim) ![](https://img.shields.io/github/stars/whisperpine/quickfix-messages.nvim) ![](https://img.shields.io/github/last-commit/whisperpine/quickfix-messages.nvim) ![](https://img.shields.io/github/commit-activity/y/whisperpine/quickfix-messages.nvim)
 - [shmerl/quickfixdel](https://github.com/shmerl/quickfixdel) ![](https://img.shields.io/github/stars/shmerl/quickfixdel) ![](https://img.shields.io/github/last-commit/shmerl/quickfixdel) ![](https://img.shields.io/github/commit-activity/y/shmerl/quickfixdel)
+- [ddickstein/qf-delete.nvim](https://github.com/ddickstein/qf-delete.nvim) ![](https://img.shields.io/github/stars/ddickstein/qf-delete.nvim) ![](https://img.shields.io/github/last-commit/ddickstein/qf-delete.nvim) ![](https://img.shields.io/github/commit-activity/y/ddickstein/qf-delete.nvim)
 
 ### Output the list to another format
 

--- a/readme.md
+++ b/readme.md
@@ -320,6 +320,7 @@
 
 - [julienvincent/nvim-paredit](https://github.com/julienvincent/nvim-paredit) ![](https://img.shields.io/github/stars/julienvincent/nvim-paredit) ![](https://img.shields.io/github/last-commit/julienvincent/nvim-paredit) ![](https://img.shields.io/github/commit-activity/y/julienvincent/nvim-paredit)
   - [dnebauer/dn-markdown.nvim](https://github.com/dnebauer/dn-markdown.nvim) ![](https://img.shields.io/github/stars/dnebauer/dn-markdown.nvim) ![](https://img.shields.io/github/last-commit/dnebauer/dn-markdown.nvim) ![](https://img.shields.io/github/commit-activity/y/dnebauer/dn-markdown.nvim)
+- [carlinigraphy/structured.nvim](https://github.com/carlinigraphy/structured.nvim) ![](https://img.shields.io/github/stars/carlinigraphy/structured.nvim) ![](https://img.shields.io/github/last-commit/carlinigraphy/structured.nvim) ![](https://img.shields.io/github/commit-activity/y/carlinigraphy/structured.nvim)
 
 ### Edit Prediction
 

--- a/syntax_highlight.md
+++ b/syntax_highlight.md
@@ -107,6 +107,7 @@
 - [wsdjeg/cpicker.nvim](https://github.com/wsdjeg/cpicker.nvim) ![](https://img.shields.io/github/stars/wsdjeg/cpicker.nvim) ![](https://img.shields.io/github/last-commit/wsdjeg/cpicker.nvim) ![](https://img.shields.io/github/commit-activity/y/wsdjeg/cpicker.nvim)
 - [MarcosTypeAP/color-picker.nvim](https://github.com/MarcosTypeAP/color-picker.nvim) ![](https://img.shields.io/github/stars/MarcosTypeAP/color-picker.nvim) ![](https://img.shields.io/github/last-commit/MarcosTypeAP/color-picker.nvim) ![](https://img.shields.io/github/commit-activity/y/MarcosTypeAP/color-picker.nvim)
 - [eero-lehtinen/oklch-color-picker.nvim](https://github.com/eero-lehtinen/oklch-color-picker.nvim) ![](https://img.shields.io/github/stars/eero-lehtinen/oklch-color-picker.nvim) ![](https://img.shields.io/github/last-commit/eero-lehtinen/oklch-color-picker.nvim) ![](https://img.shields.io/github/commit-activity/y/eero-lehtinen/oklch-color-picker.nvim)
+- [barium-bromide/colortils.nvim](https://github.com/barium-bromide/colortils.nvim) ![](https://img.shields.io/github/stars/barium-bromide/colortils.nvim) ![](https://img.shields.io/github/last-commit/barium-bromide/colortils.nvim) ![](https://img.shields.io/github/commit-activity/y/barium-bromide/colortils.nvim)
 
 ### Color Creator
 

--- a/web-service.md
+++ b/web-service.md
@@ -219,6 +219,7 @@
 - [mmuldo/spotify.nvim](https://github.com/mmuldo/spotify.nvim) ![](https://img.shields.io/github/stars/mmuldo/spotify.nvim) ![](https://img.shields.io/github/last-commit/mmuldo/spotify.nvim) ![](https://img.shields.io/github/commit-activity/y/mmuldo/spotify.nvim)
 - [jfinnis/spotify-notification.nvim](https://github.com/jfinnis/spotify-notification.nvim) ![](https://img.shields.io/github/stars/jfinnis/spotify-notification.nvim) ![](https://img.shields.io/github/last-commit/jfinnis/spotify-notification.nvim) ![](https://img.shields.io/github/commit-activity/y/jfinnis/spotify-notification.nvim)
 - [FocusThen/music-player.nvim](https://github.com/FocusThen/music-player.nvim) ![](https://img.shields.io/github/stars/FocusThen/music-player.nvim) ![](https://img.shields.io/github/last-commit/FocusThen/music-player.nvim) ![](https://img.shields.io/github/commit-activity/y/FocusThen/music-player.nvim)
+- [coreyb-git/spotify-player.nvim](https://github.com/coreyb-git/spotify-player.nvim) ![](https://img.shields.io/github/stars/coreyb-git/spotify-player.nvim) ![](https://img.shields.io/github/last-commit/coreyb-git/spotify-player.nvim) ![](https://img.shields.io/github/commit-activity/y/coreyb-git/spotify-player.nvim)
 
 ### StackOverflow
 


### PR DESCRIPTION
|URL|Category|Reason|
|---|---|---|
|https://github.com/barium-bromide/colortils.nvim|Syntax / Color picker|The plugin provides tools for picking and manipulating colors inside Neovim, similar to other syntax/color picker tools in the vector DB. It fits best under "Syntax / Color picker".|
|https://github.com/carlinigraphy/structured.nvim|Editing support / Parenthetical edit|The plugin provides structural editing capabilities leveraging Treesitter to manipulate balanced expressions and syntax nodes, which fits well within parenthetical or structural editing support.|
|https://github.com/coreyb-git/spotify-player.nvim|Web / Spotify|The plugin is a Neovim client for controlling Spotify playback, similar to other plugins categorized under "Web / Spotify" that directly interface with the Spotify service.
|https://github.com/ddickstein/qf-delete.nvim|Quickfix|The plugin provides functionality to selectively delete entries from the Neovim quickfix list, which aligns with other plugins in the Quickfix category.|
|https://github.com/double-tilde/treesitter-tag-hop.nvim|Jump / Treesitter Node|This plugin allows quick navigation ("hopping") between syntax nodes or tags identified via Treesitter, facilitating fast code navigation based on AST nodes. It fits well in the "Jump / Treesitter Node" category as it focuses on movement within the code using Treesitter's parsed syntax tree.|
|https://github.com/fasterius/slime-peek.nvim|Debug / REPL|The plugin integrates Neovim with REPLs similar to the original "slime" concept, allowing code execution and interaction within the editor. This fits best under Debug / REPL since it facilitates live code evaluation and REPL workflows.|
|https://github.com/timantipov/md-table-tidy.nvim|Documentation / Markdown / Markdown table|The plugin tidies and formats Markdown tables, similar to other plugins focused on editing and managing Markdown tables.|
