### PR TITLE
Add

### DIFF
--- a/auto-insert.md
+++ b/auto-insert.md
@@ -74,6 +74,7 @@
 - [rareitems/put_at_end.nvim](https://github.com/rareitems/put_at_end.nvim) ![](https://img.shields.io/github/stars/rareitems/put_at_end.nvim) ![](https://img.shields.io/github/last-commit/rareitems/put_at_end.nvim) ![](https://img.shields.io/github/commit-activity/y/rareitems/put_at_end.nvim)
 - [Jumas-Cola/cosco.nvim](https://github.com/Jumas-Cola/cosco.nvim) ![](https://img.shields.io/github/stars/Jumas-Cola/cosco.nvim) ![](https://img.shields.io/github/last-commit/Jumas-Cola/cosco.nvim) ![](https://img.shields.io/github/commit-activity/y/Jumas-Cola/cosco.nvim)
 - [saifulapm/commasemi.nvim](https://github.com/saifulapm/commasemi.nvim) ![](https://img.shields.io/github/stars/saifulapm/commasemi.nvim) ![](https://img.shields.io/github/last-commit/saifulapm/commasemi.nvim) ![](https://img.shields.io/github/commit-activity/y/saifulapm/commasemi.nvim)
+- [JamieByers/semicolonify.nvim](https://github.com/JamieByers/semicolonify.nvim) ![](https://img.shields.io/github/stars/JamieByers/semicolonify.nvim) ![](https://img.shields.io/github/last-commit/JamieByers/semicolonify.nvim) ![](https://img.shields.io/github/commit-activity/y/JamieByers/semicolonify.nvim)
 
 ## Auto convert
 

--- a/note-taking.md
+++ b/note-taking.md
@@ -264,6 +264,7 @@
 - [jmtd/nvim-microwiki](https://github.com/jmtd/nvim-microwiki) ![](https://img.shields.io/github/stars/jmtd/nvim-microwiki) ![](https://img.shields.io/github/last-commit/jmtd/nvim-microwiki) ![](https://img.shields.io/github/commit-activity/y/jmtd/nvim-microwiki)
 - [TyrannosaurusLjx/wiki.nvim](https://github.com/TyrannosaurusLjx/wiki.nvim) ![](https://img.shields.io/github/stars/TyrannosaurusLjx/wiki.nvim) ![](https://img.shields.io/github/last-commit/TyrannosaurusLjx/wiki.nvim) ![](https://img.shields.io/github/commit-activity/y/TyrannosaurusLjx/wiki.nvim)
 - [yilisharcs/wikibrowse.nvim](https://github.com/yilisharcs/wikibrowse.nvim) ![](https://img.shields.io/github/stars/yilisharcs/wikibrowse.nvim) ![](https://img.shields.io/github/last-commit/yilisharcs/wikibrowse.nvim) ![](https://img.shields.io/github/commit-activity/y/yilisharcs/wikibrowse.nvim)
+- [yeasin50/wikilink.nvim](https://github.com/yeasin50/wikilink.nvim) ![](https://img.shields.io/github/stars/yeasin50/wikilink.nvim) ![](https://img.shields.io/github/last-commit/yeasin50/wikilink.nvim) ![](https://img.shields.io/github/commit-activity/y/yeasin50/wikilink.nvim)
 
 ### VimWiki
 

--- a/search_replace_grep_select.md
+++ b/search_replace_grep_select.md
@@ -182,6 +182,7 @@
 - [4thwithme/ss.nvim](https://github.com/4thwithme/ss.nvim) ![](https://img.shields.io/github/stars/4thwithme/ss.nvim) ![](https://img.shields.io/github/last-commit/4thwithme/ss.nvim) ![](https://img.shields.io/github/commit-activity/y/4thwithme/ss.nvim)
 - [jborkowski/telescope-inflect.nvim](https://github.com/jborkowski/telescope-inflect.nvim) ![](https://img.shields.io/github/stars/jborkowski/telescope-inflect.nvim) ![](https://img.shields.io/github/last-commit/jborkowski/telescope-inflect.nvim) ![](https://img.shields.io/github/commit-activity/y/jborkowski/telescope-inflect.nvim)
 - [ElanMedoff/rg-glob-builder.nvim](https://github.com/ElanMedoff/rg-glob-builder.nvim) ![](https://img.shields.io/github/stars/ElanMedoff/rg-glob-builder.nvim) ![](https://img.shields.io/github/last-commit/ElanMedoff/rg-glob-builder.nvim) ![](https://img.shields.io/github/commit-activity/y/ElanMedoff/rg-glob-builder.nvim)
+- [stuckinsnow/rg-lua.nvim](https://github.com/stuckinsnow/rg-lua.nvim) ![](https://img.shields.io/github/stars/stuckinsnow/rg-lua.nvim) ![](https://img.shields.io/github/last-commit/stuckinsnow/rg-lua.nvim) ![](https://img.shields.io/github/commit-activity/y/stuckinsnow/rg-lua.nvim)
 
 ### AST (Semantic search)
 

--- a/vscode-features.md
+++ b/vscode-features.md
@@ -37,6 +37,7 @@
 - [pkage/coauthor.nvim](https://github.com/pkage/coauthor.nvim) ![](https://img.shields.io/github/stars/pkage/coauthor.nvim) ![](https://img.shields.io/github/last-commit/pkage/coauthor.nvim) ![](https://img.shields.io/github/commit-activity/y/pkage/coauthor.nvim)
 - [skeletony007/pair.nvim](https://github.com/skeletony007/pair.nvim) ![](https://img.shields.io/github/stars/skeletony007/pair.nvim) ![](https://img.shields.io/github/last-commit/skeletony007/pair.nvim) ![](https://img.shields.io/github/commit-activity/y/skeletony007/pair.nvim)
 - [azratul/live-share.nvim](https://github.com/azratul/live-share.nvim) ![](https://img.shields.io/github/stars/azratul/live-share.nvim) ![](https://img.shields.io/github/last-commit/azratul/live-share.nvim) ![](https://img.shields.io/github/commit-activity/y/azratul/live-share.nvim)
+- [EmreDay1/collab.nvim](https://github.com/EmreDay1/collab.nvim) ![](https://img.shields.io/github/stars/EmreDay1/collab.nvim) ![](https://img.shields.io/github/last-commit/EmreDay1/collab.nvim) ![](https://img.shields.io/github/commit-activity/y/EmreDay1/collab.nvim)
 
 ### IDE feature
 


### PR DESCRIPTION
|URL|Category|Reason|
|---|---|---|
|https://github.com/DavisRayM/term-manager.nvim|Terminal / Manager|term-manager.nvim is a Neovim plugin designed to manage multiple terminal instances within Neovim, allowing users to easily toggle, create, and switch between terminals. This functionality fits best under a terminal management category.
|https://github.com/EmreDay1/collab.nvim|VS Code features / Collaborative Editing|collab.nvim is a Neovim plugin that enables real-time collaborative editing, allowing multiple users to edit the same file simultaneously, similar to features found in VS Code Live Share and other collaborative editing tools.|
|https://github.com/JamieByers/semicolonify.nvim|Auto insert semicolon|The plugin automatically inserts semicolons at the end of lines for supported languages, fitting the "Auto insert semicolon" category.
|https://github.com/SirWrexes/invert.nvim|New Category (Editor Appearance / Theme Enhancement)|invert.nvim is a Neovim plugin that automatically toggles between light and dark themes based on the time of day, enhancing the editor's appearance dynamically.|
|https://github.com/aekasitt/oxeye.nvim|Language specific / Programing Language / Framework / OCaml|Oxeye.nvim is a Neovim plugin designed to provide support for the OCaml programming language, offering features such as syntax highlighting, linting, and tooling integration which fit into the category of language specific frameworks for OCaml.
|https://github.com/stuckinsnow/rg-lua.nvim|Grep|The plugin provides an interface to use ripgrep (rg) from within Neovim using Lua, facilitating fast and efficient text searching, which fits the "Grep" category.|
|https://github.com/yeasin50/wikilink.nvim|Note Taking / Wiki|The plugin provides Wiki-style link support for Neovim, enabling creation and navigation of wiki links within markdown or text files, similar to note-taking or personal wiki management plugins.|
