### PR TITLE
Add

### DIFF
--- a/calculation.md
+++ b/calculation.md
@@ -20,6 +20,7 @@
 - [22ispencer/calc.nvim](https://github.com/22ispencer/calc.nvim) ![](https://img.shields.io/github/stars/22ispencer/calc.nvim) ![](https://img.shields.io/github/last-commit/22ispencer/calc.nvim) ![](https://img.shields.io/github/commit-activity/y/22ispencer/calc.nvim)
 - [josephburgess/nvumi](https://github.com/josephburgess/nvumi) ![](https://img.shields.io/github/stars/josephburgess/nvumi) ![](https://img.shields.io/github/last-commit/josephburgess/nvumi) ![](https://img.shields.io/github/commit-activity/y/josephburgess/nvumi)
 - [aehabdelouadoud/nvim-calc](https://github.com/aehabdelouadoud/nvim-calc) ![](https://img.shields.io/github/stars/aehabdelouadoud/nvim-calc) ![](https://img.shields.io/github/last-commit/aehabdelouadoud/nvim-calc) ![](https://img.shields.io/github/commit-activity/y/aehabdelouadoud/nvim-calc)
+- [Flokkq/calc.nvim](https://github.com/Flokkq/calc.nvim) ![](https://img.shields.io/github/stars/Flokkq/calc.nvim) ![](https://img.shields.io/github/last-commit/Flokkq/calc.nvim) ![](https://img.shields.io/github/commit-activity/y/Flokkq/calc.nvim)
 
 ### Time
 

--- a/documentation.md
+++ b/documentation.md
@@ -398,6 +398,7 @@
 ### Mindmap
 
 - [gustadev24/markmap_preview.nvim](https://github.com/gustadev24/markmap_preview.nvim) ![](https://img.shields.io/github/stars/gustadev24/markmap_preview.nvim) ![](https://img.shields.io/github/last-commit/gustadev24/markmap_preview.nvim) ![](https://img.shields.io/github/commit-activity/y/gustadev24/markmap_preview.nvim)
+- [obsidian-nvim/obsidian-markmap.nvim](https://github.com/obsidian-nvim/obsidian-markmap.nvim) ![](https://img.shields.io/github/stars/obsidian-nvim/obsidian-markmap.nvim) ![](https://img.shields.io/github/last-commit/obsidian-nvim/obsidian-markmap.nvim) ![](https://img.shields.io/github/commit-activity/y/obsidian-nvim/obsidian-markmap.nvim)
 
 ### PDF
 

--- a/git-github.md
+++ b/git-github.md
@@ -394,6 +394,7 @@
 - [obayemi/jjsigns.nvim](https://github.com/obayemi/jjsigns.nvim) ![](https://img.shields.io/github/stars/obayemi/jjsigns.nvim) ![](https://img.shields.io/github/last-commit/obayemi/jjsigns.nvim) ![](https://img.shields.io/github/commit-activity/y/obayemi/jjsigns.nvim)
 - [CharlesTaylor7/majjit.nvim](https://github.com/CharlesTaylor7/majjit.nvim) ![](https://img.shields.io/github/stars/CharlesTaylor7/majjit.nvim) ![](https://img.shields.io/github/last-commit/CharlesTaylor7/majjit.nvim) ![](https://img.shields.io/github/commit-activity/y/CharlesTaylor7/majjit.nvim)
 - [solsystemlabs/jujutsu.nvim](https://github.com/solsystemlabs/jujutsu.nvim) ![](https://img.shields.io/github/stars/solsystemlabs/jujutsu.nvim) ![](https://img.shields.io/github/last-commit/solsystemlabs/jujutsu.nvim) ![](https://img.shields.io/github/commit-activity/y/solsystemlabs/jujutsu.nvim)
+- [maladroitthief/jj-minidiff.nvim](https://github.com/maladroitthief/jj-minidiff.nvim) ![](https://img.shields.io/github/stars/maladroitthief/jj-minidiff.nvim) ![](https://img.shields.io/github/last-commit/maladroitthief/jj-minidiff.nvim) ![](https://img.shields.io/github/commit-activity/y/maladroitthief/jj-minidiff.nvim)
 
 ### diff
 

--- a/music.md
+++ b/music.md
@@ -39,6 +39,7 @@
 - [wsdjeg/music-player.nvim](https://github.com/wsdjeg/music-player.nvim) ![](https://img.shields.io/github/stars/wsdjeg/music-player.nvim) ![](https://img.shields.io/github/last-commit/wsdjeg/music-player.nvim) ![](https://img.shields.io/github/commit-activity/y/wsdjeg/music-player.nvim)
 - [liraymond04/ass-mpv.nvim](https://github.com/liraymond04/ass-mpv.nvim) ![](https://img.shields.io/github/stars/liraymond04/ass-mpv.nvim) ![](https://img.shields.io/github/last-commit/liraymond04/ass-mpv.nvim) ![](https://img.shields.io/github/commit-activity/y/liraymond04/ass-mpv.nvim)
 - [neo451/musicfox.nvim](https://github.com/neo451/musicfox.nvim) ![](https://img.shields.io/github/stars/neo451/musicfox.nvim) ![](https://img.shields.io/github/last-commit/neo451/musicfox.nvim) ![](https://img.shields.io/github/commit-activity/y/neo451/musicfox.nvim)
+- [thevahidal/deej.nvim](https://github.com/thevahidal/deej.nvim) ![](https://img.shields.io/github/stars/thevahidal/deej.nvim) ![](https://img.shields.io/github/last-commit/thevahidal/deej.nvim) ![](https://img.shields.io/github/commit-activity/y/thevahidal/deej.nvim)
 
 ### sapf
 

--- a/note-taking.md
+++ b/note-taking.md
@@ -174,6 +174,7 @@
 - [ethanamaher/todo-telescope.nvim](https://github.com/ethanamaher/todo-telescope.nvim) ![](https://img.shields.io/github/stars/ethanamaher/todo-telescope.nvim) ![](https://img.shields.io/github/last-commit/ethanamaher/todo-telescope.nvim) ![](https://img.shields.io/github/commit-activity/y/ethanamaher/todo-telescope.nvim)
 - [zaffron/todo-md.nvim](https://github.com/zaffron/todo-md.nvim) ![](https://img.shields.io/github/stars/zaffron/todo-md.nvim) ![](https://img.shields.io/github/last-commit/zaffron/todo-md.nvim) ![](https://img.shields.io/github/commit-activity/y/zaffron/todo-md.nvim)
 - [FrancoAseglio/todo-sidebar.nvim](https://github.com/FrancoAseglio/todo-sidebar.nvim) ![](https://img.shields.io/github/stars/FrancoAseglio/todo-sidebar.nvim) ![](https://img.shields.io/github/last-commit/FrancoAseglio/todo-sidebar.nvim) ![](https://img.shields.io/github/commit-activity/y/FrancoAseglio/todo-sidebar.nvim)
+- [baltavay/quests.nvim](https://github.com/baltavay/quests.nvim) ![](https://img.shields.io/github/stars/baltavay/quests.nvim) ![](https://img.shields.io/github/last-commit/baltavay/quests.nvim) ![](https://img.shields.io/github/commit-activity/y/baltavay/quests.nvim)
 
 #### Taskwarrior
 

--- a/syntax_highlight.md
+++ b/syntax_highlight.md
@@ -50,6 +50,7 @@
 - [JoseConseco/hl_manager.nvim](https://github.com/JoseConseco/hl_manager.nvim) ![](https://img.shields.io/github/stars/JoseConseco/hl_manager.nvim) ![](https://img.shields.io/github/last-commit/JoseConseco/hl_manager.nvim) ![](https://img.shields.io/github/commit-activity/y/JoseConseco/hl_manager.nvim)
 - [bwpge/colorful.nvim](https://github.com/bwpge/colorful.nvim) ![](https://img.shields.io/github/stars/bwpge/colorful.nvim) ![](https://img.shields.io/github/last-commit/bwpge/colorful.nvim) ![](https://img.shields.io/github/commit-activity/y/bwpge/colorful.nvim)
 - [trippwill/modechar.nvim](https://github.com/trippwill/modechar.nvim) ![](https://img.shields.io/github/stars/trippwill/modechar.nvim) ![](https://img.shields.io/github/last-commit/trippwill/modechar.nvim) ![](https://img.shields.io/github/commit-activity/y/trippwill/modechar.nvim)
+- [LucasGualtieri/visual-highlight.nvim](https://github.com/LucasGualtieri/visual-highlight.nvim) ![](https://img.shields.io/github/stars/LucasGualtieri/visual-highlight.nvim) ![](https://img.shields.io/github/last-commit/LucasGualtieri/visual-highlight.nvim) ![](https://img.shields.io/github/commit-activity/y/LucasGualtieri/visual-highlight.nvim)
 
 ### Delimiter
 
@@ -159,6 +160,7 @@
 - [yashodhanketkar/themeui.nvim](https://github.com/yashodhanketkar/themeui.nvim) ![](https://img.shields.io/github/stars/yashodhanketkar/themeui.nvim) ![](https://img.shields.io/github/last-commit/yashodhanketkar/themeui.nvim) ![](https://img.shields.io/github/commit-activity/y/yashodhanketkar/themeui.nvim)
 - [Rimkomatic/switchscheme.nvim](https://github.com/Rimkomatic/switchscheme.nvim) ![](https://img.shields.io/github/stars/Rimkomatic/switchscheme.nvim) ![](https://img.shields.io/github/last-commit/Rimkomatic/switchscheme.nvim) ![](https://img.shields.io/github/commit-activity/y/Rimkomatic/switchscheme.nvim)
 - [lokop5116/ThemeControl.nvim](https://github.com/lokop5116/ThemeControl.nvim) ![](https://img.shields.io/github/stars/lokop5116/ThemeControl.nvim) ![](https://img.shields.io/github/last-commit/lokop5116/ThemeControl.nvim) ![](https://img.shields.io/github/commit-activity/y/lokop5116/ThemeControl.nvim)
+- [statiolake/colorset.nvim](https://github.com/statiolake/colorset.nvim) ![](https://img.shields.io/github/stars/statiolake/colorset.nvim) ![](https://img.shields.io/github/last-commit/statiolake/colorset.nvim) ![](https://img.shields.io/github/commit-activity/y/statiolake/colorset.nvim)
 
 ### Colorscheme overwrite
 

--- a/task-runner.md
+++ b/task-runner.md
@@ -133,6 +133,7 @@
 - [cparaiso/centest.nvim](https://github.com/cparaiso/centest.nvim) ![](https://img.shields.io/github/stars/cparaiso/centest.nvim) ![](https://img.shields.io/github/last-commit/cparaiso/centest.nvim) ![](https://img.shields.io/github/commit-activity/y/cparaiso/centest.nvim)
 - [68mschmitt/project_runner.nvim](https://github.com/68mschmitt/project_runner.nvim) ![](https://img.shields.io/github/stars/68mschmitt/project_runner.nvim) ![](https://img.shields.io/github/last-commit/68mschmitt/project_runner.nvim) ![](https://img.shields.io/github/commit-activity/y/68mschmitt/project_runner.nvim)
 - [eumis/tasks.nvim](https://github.com/eumis/tasks.nvim) ![](https://img.shields.io/github/stars/eumis/tasks.nvim) ![](https://img.shields.io/github/last-commit/eumis/tasks.nvim) ![](https://img.shields.io/github/commit-activity/y/eumis/tasks.nvim)
+- [07CalC/cook.nvim](https://github.com/07CalC/cook.nvim) ![](https://img.shields.io/github/stars/07CalC/cook.nvim) ![](https://img.shields.io/github/last-commit/07CalC/cook.nvim) ![](https://img.shields.io/github/commit-activity/y/07CalC/cook.nvim)
 
 #### Shell
 
@@ -184,6 +185,7 @@
 - [calebfroese/ampcode-cli.nvim](https://github.com/calebfroese/ampcode-cli.nvim) ![](https://img.shields.io/github/stars/calebfroese/ampcode-cli.nvim) ![](https://img.shields.io/github/last-commit/calebfroese/ampcode-cli.nvim) ![](https://img.shields.io/github/commit-activity/y/calebfroese/ampcode-cli.nvim)
 - [evictedcucumber/easycmd.nvim](https://github.com/evictedcucumber/easycmd.nvim) ![](https://img.shields.io/github/stars/evictedcucumber/easycmd.nvim) ![](https://img.shields.io/github/last-commit/evictedcucumber/easycmd.nvim) ![](https://img.shields.io/github/commit-activity/y/evictedcucumber/easycmd.nvim)
 - [AvoidMe/nvim-telescope-background](https://github.com/AvoidMe/nvim-telescope-background) ![](https://img.shields.io/github/stars/AvoidMe/nvim-telescope-background) ![](https://img.shields.io/github/last-commit/AvoidMe/nvim-telescope-background) ![](https://img.shields.io/github/commit-activity/y/AvoidMe/nvim-telescope-background)
+- [Braniacsl/tauri-runner.nvim](https://github.com/Braniacsl/tauri-runner.nvim) ![](https://img.shields.io/github/stars/Braniacsl/tauri-runner.nvim) ![](https://img.shields.io/github/last-commit/Braniacsl/tauri-runner.nvim) ![](https://img.shields.io/github/commit-activity/y/Braniacsl/tauri-runner.nvim)
 
 ### Auto detect style
 


### PR DESCRIPTION
|URL|Category|Reason|
|---|---|---|
|https://github.com/07CalC/cook.nvim|Task Runner / Config file style / Lua|cook.nvim is a Neovim plugin designed to run commands and tasks based on a Lua configuration file, aligning it with other task runners that use Lua for configuration.|
|https://github.com/Braniacsl/tauri-runner.nvim|Task Runner / Command style|The plugin tauri-runner.nvim is designed to run Tauri apps from within Neovim, acting as a command-style task runner that focuses on running and managing Tauri projects directly in the editor. This aligns it with other command-style task runners.
|https://github.com/Flokkq/calc.nvim|Calculation|The plugin is a calculator integration for Neovim, enabling inline calculations within the editor, which fits the Calculation category given the similarity to other calculator plugins listed.|
|https://github.com/LucasGualtieri/visual-highlight.nvim|Highlight|The plugin provides enhanced visual highlight features in Neovim, specifically improving the visual feedback during text selection and editing, which aligns with the Highlight category.
|https://github.com/MihneaTs1/perset.nvim|Neovim / Session Management|perset.nvim is a Neovim plugin for managing persistent sessions, allowing users to save, load, and switch between different editing sessions easily. This fits best under session management within Neovim plugins.
|https://github.com/arsyhiy/example.nvim|Plugin Development / Example / Template|The repository provides a minimal example of a Neovim Lua plugin, serving as a template or starting point for plugin development rather than adding specific user-facing functionality.
|https://github.com/baltavay/quests.nvim|Note Taking / ToDo|quests.nvim is a Neovim plugin designed to manage and track tasks, quests, or goals within the editor, similar to a task or to-do manager integrated into Neovim.|
|https://github.com/maladroitthief/jj-minidiff.nvim|Jujutsu(jj)|The plugin integrates with the Jujutsu version control system, providing minimal diff visualization tailored for jj, indicating it belongs in the Jujutsu(jj) category.|
|https://github.com/obsidian-nvim/obsidian-markmap.nvim|Documentation / Mindmap|This plugin integrates Markmap (a mind map visualization tool for Markdown) with Obsidian notes in Neovim, focusing on rendering Markdown notes as mind maps.|
|https://github.com/statiolake/colorset.nvim|Syntax / Colorscheme switcher|The plugin provides a way to switch and manage colorschemes in Neovim, aligning it with other colorscheme switcher plugins.|
|https://github.com/thevahidal/deej.nvim|Music|The plugin is a Neovim client for the Deezer music streaming service, enabling users to control and interact with Deezer directly from Neovim.|
