### PR TITLE
Add

### DIFF
--- a/debugger_repl.md
+++ b/debugger_repl.md
@@ -63,6 +63,7 @@
 - [miroshQa/debugmaster.nvim](https://github.com/miroshQa/debugmaster.nvim) ![](https://img.shields.io/github/stars/miroshQa/debugmaster.nvim) ![](https://img.shields.io/github/last-commit/miroshQa/debugmaster.nvim) ![](https://img.shields.io/github/commit-activity/y/miroshQa/debugmaster.nvim)
 - [MrEhbr/dap-rust.nvim](https://github.com/MrEhbr/dap-rust.nvim) ![](https://img.shields.io/github/stars/MrEhbr/dap-rust.nvim) ![](https://img.shields.io/github/last-commit/MrEhbr/dap-rust.nvim) ![](https://img.shields.io/github/commit-activity/y/MrEhbr/dap-rust.nvim)
 - [docker/nvim-dap-docker](https://github.com/docker/nvim-dap-docker) ![](https://img.shields.io/github/stars/docker/nvim-dap-docker) ![](https://img.shields.io/github/last-commit/docker/nvim-dap-docker) ![](https://img.shields.io/github/commit-activity/y/docker/nvim-dap-docker)
+- [mwcz/rust-termdebug.nvim](https://github.com/mwcz/rust-termdebug.nvim) ![](https://img.shields.io/github/stars/mwcz/rust-termdebug.nvim) ![](https://img.shields.io/github/last-commit/mwcz/rust-termdebug.nvim) ![](https://img.shields.io/github/commit-activity/y/mwcz/rust-termdebug.nvim)
 
 #### Launch.json
 

--- a/filer.md
+++ b/filer.md
@@ -86,6 +86,7 @@
 - [otavioschwanck/fzf-lua-explorer.nvim](https://github.com/otavioschwanck/fzf-lua-explorer.nvim) ![](https://img.shields.io/github/stars/otavioschwanck/fzf-lua-explorer.nvim) ![](https://img.shields.io/github/last-commit/otavioschwanck/fzf-lua-explorer.nvim) ![](https://img.shields.io/github/commit-activity/y/otavioschwanck/fzf-lua-explorer.nvim)
 - [alucherdi/hand-of-god](https://github.com/alucherdi/hand-of-god) ![](https://img.shields.io/github/stars/alucherdi/hand-of-god) ![](https://img.shields.io/github/last-commit/alucherdi/hand-of-god) ![](https://img.shields.io/github/commit-activity/y/alucherdi/hand-of-god)
 - [TrsNium/feather.nvim](https://github.com/TrsNium/feather.nvim) ![](https://img.shields.io/github/stars/TrsNium/feather.nvim) ![](https://img.shields.io/github/last-commit/TrsNium/feather.nvim) ![](https://img.shields.io/github/commit-activity/y/TrsNium/feather.nvim)
+- [alexfinger21/nvim-tree-test.lua](https://github.com/alexfinger21/nvim-tree-test.lua) ![](https://img.shields.io/github/stars/alexfinger21/nvim-tree-test.lua) ![](https://img.shields.io/github/last-commit/alexfinger21/nvim-tree-test.lua) ![](https://img.shields.io/github/commit-activity/y/alexfinger21/nvim-tree-test.lua)
 
 ### gx
 

--- a/git-github.md
+++ b/git-github.md
@@ -239,6 +239,7 @@
 - [Yu-Leo/blame-column.nvim](https://github.com/Yu-Leo/blame-column.nvim) ![](https://img.shields.io/github/stars/Yu-Leo/blame-column.nvim) ![](https://img.shields.io/github/last-commit/Yu-Leo/blame-column.nvim) ![](https://img.shields.io/github/commit-activity/y/Yu-Leo/blame-column.nvim)
 - [ethanamaher/better-git-blame.nvim](https://github.com/ethanamaher/better-git-blame.nvim) ![](https://img.shields.io/github/stars/ethanamaher/better-git-blame.nvim) ![](https://img.shields.io/github/last-commit/ethanamaher/better-git-blame.nvim) ![](https://img.shields.io/github/commit-activity/y/ethanamaher/better-git-blame.nvim)
 - [art-vasilyev/gerrit-blame.nvim](https://github.com/art-vasilyev/gerrit-blame.nvim) ![](https://img.shields.io/github/stars/art-vasilyev/gerrit-blame.nvim) ![](https://img.shields.io/github/last-commit/art-vasilyev/gerrit-blame.nvim) ![](https://img.shields.io/github/commit-activity/y/art-vasilyev/gerrit-blame.nvim)
+- [yt20chill/inline_git_blame.nvim](https://github.com/yt20chill/inline_git_blame.nvim) ![](https://img.shields.io/github/stars/yt20chill/inline_git_blame.nvim) ![](https://img.shields.io/github/last-commit/yt20chill/inline_git_blame.nvim) ![](https://img.shields.io/github/commit-activity/y/yt20chill/inline_git_blame.nvim)
 
 ### git log
 
@@ -547,6 +548,7 @@
 - [art-vasilyev/yapath.nvim](https://github.com/art-vasilyev/yapath.nvim) ![](https://img.shields.io/github/stars/art-vasilyev/yapath.nvim) ![](https://img.shields.io/github/last-commit/art-vasilyev/yapath.nvim) ![](https://img.shields.io/github/commit-activity/y/art-vasilyev/yapath.nvim)
 - [ChromaMaster/gitpermalink.nvim](https://github.com/ChromaMaster/gitpermalink.nvim) ![](https://img.shields.io/github/stars/ChromaMaster/gitpermalink.nvim) ![](https://img.shields.io/github/last-commit/ChromaMaster/gitpermalink.nvim) ![](https://img.shields.io/github/commit-activity/y/ChromaMaster/gitpermalink.nvim)
 - [tapihdev/cfp.nvim](https://github.com/tapihdev/cfp.nvim) ![](https://img.shields.io/github/stars/tapihdev/cfp.nvim) ![](https://img.shields.io/github/last-commit/tapihdev/cfp.nvim) ![](https://img.shields.io/github/commit-activity/y/tapihdev/cfp.nvim)
+- [ipetrovbg/nvim-gh-browse](https://github.com/ipetrovbg/nvim-gh-browse) ![](https://img.shields.io/github/stars/ipetrovbg/nvim-gh-browse) ![](https://img.shields.io/github/last-commit/ipetrovbg/nvim-gh-browse) ![](https://img.shields.io/github/commit-activity/y/ipetrovbg/nvim-gh-browse)
 
 ### Image
 

--- a/integration-apps.md
+++ b/integration-apps.md
@@ -80,6 +80,7 @@
 
 - [Massolari/forem.nvim](https://github.com/Massolari/forem.nvim) ![](https://img.shields.io/github/stars/Massolari/forem.nvim) ![](https://img.shields.io/github/last-commit/Massolari/forem.nvim) ![](https://img.shields.io/github/commit-activity/y/Massolari/forem.nvim)
 - [gwatcha/reaper-keys](https://github.com/gwatcha/reaper-keys) ![](https://img.shields.io/github/stars/gwatcha/reaper-keys) ![](https://img.shields.io/github/last-commit/gwatcha/reaper-keys) ![](https://img.shields.io/github/commit-activity/y/gwatcha/reaper-keys)
+- [Piotr1215/docusaurus.nvim](https://github.com/Piotr1215/docusaurus.nvim) ![](https://img.shields.io/github/stars/Piotr1215/docusaurus.nvim) ![](https://img.shields.io/github/last-commit/Piotr1215/docusaurus.nvim) ![](https://img.shields.io/github/commit-activity/y/Piotr1215/docusaurus.nvim)
 
 ### Other Editor
 

--- a/js_ts.md
+++ b/js_ts.md
@@ -93,6 +93,7 @@
 - [mattpatterson94/fzf-lua-import.nvim](https://github.com/mattpatterson94/fzf-lua-import.nvim) ![](https://img.shields.io/github/stars/mattpatterson94/fzf-lua-import.nvim) ![](https://img.shields.io/github/last-commit/mattpatterson94/fzf-lua-import.nvim) ![](https://img.shields.io/github/commit-activity/y/mattpatterson94/fzf-lua-import.nvim)
 - [dimpu/import-size.nvim](https://github.com/dimpu/import-size.nvim) ![](https://img.shields.io/github/stars/dimpu/import-size.nvim) ![](https://img.shields.io/github/last-commit/dimpu/import-size.nvim) ![](https://img.shields.io/github/commit-activity/y/dimpu/import-size.nvim)
 - [ducks/nvim-vandelay](https://github.com/ducks/nvim-vandelay) ![](https://img.shields.io/github/stars/ducks/nvim-vandelay) ![](https://img.shields.io/github/last-commit/ducks/nvim-vandelay) ![](https://img.shields.io/github/commit-activity/y/ducks/nvim-vandelay)
+- [stuckinsnow/import-size.nvim](https://github.com/stuckinsnow/import-size.nvim) ![](https://img.shields.io/github/stars/stuckinsnow/import-size.nvim) ![](https://img.shields.io/github/last-commit/stuckinsnow/import-size.nvim) ![](https://img.shields.io/github/commit-activity/y/stuckinsnow/import-size.nvim)
 
 ### console.log
 

--- a/protocol.md
+++ b/protocol.md
@@ -35,6 +35,7 @@
 - [yonchando/http.nvim](https://github.com/yonchando/http.nvim) ![](https://img.shields.io/github/stars/yonchando/http.nvim) ![](https://img.shields.io/github/last-commit/yonchando/http.nvim) ![](https://img.shields.io/github/commit-activity/y/yonchando/http.nvim)
 - [nilszeilon/post.nvim](https://github.com/nilszeilon/post.nvim) ![](https://img.shields.io/github/stars/nilszeilon/post.nvim) ![](https://img.shields.io/github/last-commit/nilszeilon/post.nvim) ![](https://img.shields.io/github/commit-activity/y/nilszeilon/post.nvim)
 - [ecthiender/daak.nvim](https://github.com/ecthiender/daak.nvim) ![](https://img.shields.io/github/stars/ecthiender/daak.nvim) ![](https://img.shields.io/github/last-commit/ecthiender/daak.nvim) ![](https://img.shields.io/github/commit-activity/y/ecthiender/daak.nvim)
+- [Cybernetics354/mayohttp.nvim](https://github.com/Cybernetics354/mayohttp.nvim) ![](https://img.shields.io/github/stars/Cybernetics354/mayohttp.nvim) ![](https://img.shields.io/github/last-commit/Cybernetics354/mayohttp.nvim) ![](https://img.shields.io/github/commit-activity/y/Cybernetics354/mayohttp.nvim)
 
 #### Status
 


### PR DESCRIPTION
|URL|Category|Reason|
|---|---|---|
|https://github.com/Cybernetics354/mayohttp.nvim|Protocol / HTTP / Request|The plugin provides HTTP request capabilities within Neovim, similar to other HTTP client plugins, making it appropriate for the Protocol / HTTP / Request category.|
|https://github.com/Ktsierra/nvim-expo-tools|New Category (Expo / React Native Development Tools)|This plugin provides integration and tooling for managing Expo projects within Neovim, streamlining React Native development workflows, which is distinct from general LSP or configuration tools.|
|https://github.com/LuxVim/nvim-luxmotion|Motion / Jumping|nvim-luxmotion is a Neovim plugin that provides enhanced jumping and motion capabilities, allowing users to quickly move around buffers with more interactive and efficient cursor motions. It fits best under the "Motion / Jumping" category because it focuses on improving navigation within the text.
|https://github.com/Piotr1215/docusaurus.nvim|Integration with other apps|The plugin integrates Docusaurus, a documentation framework, into Neovim for managing or interacting with documentation projects.|
|https://github.com/alexfinger21/nvim-tree-test.lua|Filer|This plugin provides tests for the popular Neovim file explorer plugin nvim-tree.lua, indicating it is related to file management and file explorer functionality.|
|https://github.com/ipetrovbg/nvim-gh-browse|GitHub / Link|The plugin allows users to easily open the GitHub page for the current file or selection directly from Neovim, similar to other plugins categorized as "GitHub / Link".|
|https://github.com/mwcz/rust-termdebug.nvim|Debug / Debugger / nvim-dap extension|The plugin provides debugging support for Rust in Neovim by integrating with nvim-dap, similar to other Rust debugging extensions. It enhances the debugging experience within the editor.|
|https://github.com/stuckinsnow/import-size.nvim|Javascript/Typescript / import|The plugin shows the size of imported modules in Javascript/Typescript files, helping developers understand the impact of their imports. This fits best under the "Javascript/Typescript / import" category.|
|https://github.com/yt20chill/inline_git_blame.nvim|Git / git blame|The plugin provides inline git blame information in the editor, similar to other git blame plugins listed, showing who last modified each line of code directly within the file view.|
