### PR TITLE
Add

### DIFF
--- a/ai.md
+++ b/ai.md
@@ -330,6 +330,7 @@
 - [ianks/claude-code-ide.nvim](https://github.com/ianks/claude-code-ide.nvim) ![](https://img.shields.io/github/stars/ianks/claude-code-ide.nvim) ![](https://img.shields.io/github/last-commit/ianks/claude-code-ide.nvim) ![](https://img.shields.io/github/commit-activity/y/ianks/claude-code-ide.nvim)
 - [nandoolle/claude-code.nvim](https://github.com/nandoolle/claude-code.nvim) ![](https://img.shields.io/github/stars/nandoolle/claude-code.nvim) ![](https://img.shields.io/github/last-commit/nandoolle/claude-code.nvim) ![](https://img.shields.io/github/commit-activity/y/nandoolle/claude-code.nvim)
 - [qtnx/multiclaudecode.nvim](https://github.com/qtnx/multiclaudecode.nvim) ![](https://img.shields.io/github/stars/qtnx/multiclaudecode.nvim) ![](https://img.shields.io/github/last-commit/qtnx/multiclaudecode.nvim) ![](https://img.shields.io/github/commit-activity/y/qtnx/multiclaudecode.nvim)
+- [avifenesh/claucode.nvim](https://github.com/avifenesh/claucode.nvim) ![](https://img.shields.io/github/stars/avifenesh/claucode.nvim) ![](https://img.shields.io/github/last-commit/avifenesh/claucode.nvim) ![](https://img.shields.io/github/commit-activity/y/avifenesh/claucode.nvim)
 
 ### Amazon Q
 

--- a/completion.md
+++ b/completion.md
@@ -40,6 +40,7 @@
 - [hanspinckaers/zap.nvim](https://github.com/hanspinckaers/zap.nvim) ![](https://img.shields.io/github/stars/hanspinckaers/zap.nvim) ![](https://img.shields.io/github/last-commit/hanspinckaers/zap.nvim) ![](https://img.shields.io/github/commit-activity/y/hanspinckaers/zap.nvim)
 - [nvimdev/phoenix.nvim](https://github.com/nvimdev/phoenix.nvim) ![](https://img.shields.io/github/stars/nvimdev/phoenix.nvim) ![](https://img.shields.io/github/last-commit/nvimdev/phoenix.nvim) ![](https://img.shields.io/github/commit-activity/y/nvimdev/phoenix.nvim)
 - [wsdjeg/nvim-completion](https://github.com/wsdjeg/nvim-completion) ![](https://img.shields.io/github/stars/wsdjeg/nvim-completion) ![](https://img.shields.io/github/last-commit/wsdjeg/nvim-completion) ![](https://img.shields.io/github/commit-activity/y/wsdjeg/nvim-completion)
+- [9f2c/nvim-stream-completion](https://github.com/9f2c/nvim-stream-completion) ![](https://img.shields.io/github/stars/9f2c/nvim-stream-completion) ![](https://img.shields.io/github/last-commit/9f2c/nvim-stream-completion) ![](https://img.shields.io/github/commit-activity/y/9f2c/nvim-stream-completion)
 
 #### Made in Python
 

--- a/help.md
+++ b/help.md
@@ -90,6 +90,8 @@
 
 - [moniquelive/rfc.nvim](https://github.com/moniquelive/rfc.nvim) ![](https://img.shields.io/github/stars/moniquelive/rfc.nvim) ![](https://img.shields.io/github/last-commit/moniquelive/rfc.nvim) ![](https://img.shields.io/github/commit-activity/y/moniquelive/rfc.nvim)
 - [skykosiner/rfc.nvim](https://github.com/skykosiner/rfc.nvim) ![](https://img.shields.io/github/stars/skykosiner/rfc.nvim) ![](https://img.shields.io/github/last-commit/skykosiner/rfc.nvim) ![](https://img.shields.io/github/commit-activity/y/skykosiner/rfc.nvim)
+- [ltfiend/nvim-rfc-editor](https://github.com/ltfiend/nvim-rfc-editor) ![](https://img.shields.io/github/stars/ltfiend/nvim-rfc-editor) ![](https://img.shields.io/github/last-commit/ltfiend/nvim-rfc-editor) ![](https://img.shields.io/github/commit-activity/y/ltfiend/nvim-rfc-editor)
+- [neet-007/rfc-view.nvim](https://github.com/neet-007/rfc-view.nvim) ![](https://img.shields.io/github/stars/neet-007/rfc-view.nvim) ![](https://img.shields.io/github/last-commit/neet-007/rfc-view.nvim) ![](https://img.shields.io/github/commit-activity/y/neet-007/rfc-view.nvim)
 
 ## Reference
 

--- a/image.md
+++ b/image.md
@@ -68,6 +68,7 @@
 - [benlubas/image-save.nvim](https://github.com/benlubas/image-save.nvim) ![](https://img.shields.io/github/stars/benlubas/image-save.nvim) ![](https://img.shields.io/github/last-commit/benlubas/image-save.nvim) ![](https://img.shields.io/github/commit-activity/y/benlubas/image-save.nvim)
 - [TymekDev/freeze.nvim](https://github.com/TymekDev/freeze.nvim) ![](https://img.shields.io/github/stars/TymekDev/freeze.nvim) ![](https://img.shields.io/github/last-commit/TymekDev/freeze.nvim) ![](https://img.shields.io/github/commit-activity/y/TymekDev/freeze.nvim)
 - [watzon/goshot.nvim](https://github.com/watzon/goshot.nvim) ![](https://img.shields.io/github/stars/watzon/goshot.nvim) ![](https://img.shields.io/github/last-commit/watzon/goshot.nvim) ![](https://img.shields.io/github/commit-activity/y/watzon/goshot.nvim)
+- [pittcat/macos-screenshot.nvim](https://github.com/pittcat/macos-screenshot.nvim) ![](https://img.shields.io/github/stars/pittcat/macos-screenshot.nvim) ![](https://img.shields.io/github/last-commit/pittcat/macos-screenshot.nvim) ![](https://img.shields.io/github/commit-activity/y/pittcat/macos-screenshot.nvim)
 
 ### Screen Key (Show Typing key)
 

--- a/linter_formatter.md
+++ b/linter_formatter.md
@@ -49,6 +49,7 @@
 - [Flone-dnb/shader-formatter.nvim](https://github.com/Flone-dnb/shader-formatter.nvim) ![](https://img.shields.io/github/stars/Flone-dnb/shader-formatter.nvim) ![](https://img.shields.io/github/last-commit/Flone-dnb/shader-formatter.nvim) ![](https://img.shields.io/github/commit-activity/y/Flone-dnb/shader-formatter.nvim)
 - [GowayLee/reform.nvim](https://github.com/GowayLee/reform.nvim) ![](https://img.shields.io/github/stars/GowayLee/reform.nvim) ![](https://img.shields.io/github/last-commit/GowayLee/reform.nvim) ![](https://img.shields.io/github/commit-activity/y/GowayLee/reform.nvim)
 - [csmhowitzer/format-width.nvim](https://github.com/csmhowitzer/format-width.nvim) ![](https://img.shields.io/github/stars/csmhowitzer/format-width.nvim) ![](https://img.shields.io/github/last-commit/csmhowitzer/format-width.nvim) ![](https://img.shields.io/github/commit-activity/y/csmhowitzer/format-width.nvim)
+- [cenkalti/format-command-line.nvim](https://github.com/cenkalti/format-command-line.nvim) ![](https://img.shields.io/github/stars/cenkalti/format-command-line.nvim) ![](https://img.shields.io/github/last-commit/cenkalti/format-command-line.nvim) ![](https://img.shields.io/github/commit-activity/y/cenkalti/format-command-line.nvim)
 
 ### Trim Whitespace
 

--- a/note-taking.md
+++ b/note-taking.md
@@ -73,6 +73,7 @@
 - [DhaiShah25/zettle.nvim](https://github.com/DhaiShah25/zettle.nvim) ![](https://img.shields.io/github/stars/DhaiShah25/zettle.nvim) ![](https://img.shields.io/github/last-commit/DhaiShah25/zettle.nvim) ![](https://img.shields.io/github/commit-activity/y/DhaiShah25/zettle.nvim)
 - [teesh3rt/zeekay.nvim](https://github.com/teesh3rt/zeekay.nvim) ![](https://img.shields.io/github/stars/teesh3rt/zeekay.nvim) ![](https://img.shields.io/github/last-commit/teesh3rt/zeekay.nvim) ![](https://img.shields.io/github/commit-activity/y/teesh3rt/zeekay.nvim)
 - [breiting/nvim-zettel.nvim](https://github.com/breiting/nvim-zettel.nvim) ![](https://img.shields.io/github/stars/breiting/nvim-zettel.nvim) ![](https://img.shields.io/github/last-commit/breiting/nvim-zettel.nvim) ![](https://img.shields.io/github/commit-activity/y/breiting/nvim-zettel.nvim)
+- [sheikhevan/luhmann.nvim](https://github.com/sheikhevan/luhmann.nvim) ![](https://img.shields.io/github/stars/sheikhevan/luhmann.nvim) ![](https://img.shields.io/github/last-commit/sheikhevan/luhmann.nvim) ![](https://img.shields.io/github/commit-activity/y/sheikhevan/luhmann.nvim)
 
 ### Markdown
 

--- a/textobject_operator.md
+++ b/textobject_operator.md
@@ -49,6 +49,7 @@
 - [xlboy/swap-ternary.nvim](https://github.com/xlboy/swap-ternary.nvim) ![](https://img.shields.io/github/stars/xlboy/swap-ternary.nvim) ![](https://img.shields.io/github/last-commit/xlboy/swap-ternary.nvim) ![](https://img.shields.io/github/commit-activity/y/xlboy/swap-ternary.nvim)
 - [haolian9/textswap.nvim](https://github.com/haolian9/textswap.nvim) ![](https://img.shields.io/github/stars/haolian9/textswap.nvim) ![](https://img.shields.io/github/last-commit/haolian9/textswap.nvim) ![](https://img.shields.io/github/commit-activity/y/haolian9/textswap.nvim)
 - [phanen/text-swap.nvim](https://github.com/phanen/text-swap.nvim) ![](https://img.shields.io/github/stars/phanen/text-swap.nvim) ![](https://img.shields.io/github/last-commit/phanen/text-swap.nvim) ![](https://img.shields.io/github/commit-activity/y/phanen/text-swap.nvim)
+- [Ricie23/dyslexic-swap.nvim](https://github.com/Ricie23/dyslexic-swap.nvim) ![](https://img.shields.io/github/stars/Ricie23/dyslexic-swap.nvim) ![](https://img.shields.io/github/last-commit/Ricie23/dyslexic-swap.nvim) ![](https://img.shields.io/github/commit-activity/y/Ricie23/dyslexic-swap.nvim)
 
 ### Duplicate
 

--- a/yank_paste.md
+++ b/yank_paste.md
@@ -159,6 +159,7 @@
 - [gbprod/yanky.nvim](https://github.com/gbprod/yanky.nvim) ![](https://img.shields.io/github/stars/gbprod/yanky.nvim) ![](https://img.shields.io/github/last-commit/gbprod/yanky.nvim) ![](https://img.shields.io/github/commit-activity/y/gbprod/yanky.nvim)
 - [bfredl/nvim-miniyank](https://github.com/bfredl/nvim-miniyank) ![](https://img.shields.io/github/stars/bfredl/nvim-miniyank) ![](https://img.shields.io/github/last-commit/bfredl/nvim-miniyank) ![](https://img.shields.io/github/commit-activity/y/bfredl/nvim-miniyank)
 - [hrsh7th/nvim-pasta](https://github.com/hrsh7th/nvim-pasta) ![](https://img.shields.io/github/stars/hrsh7th/nvim-pasta) ![](https://img.shields.io/github/last-commit/hrsh7th/nvim-pasta) ![](https://img.shields.io/github/commit-activity/y/hrsh7th/nvim-pasta)
+- [sunesimonsen/killring.nvim](https://github.com/sunesimonsen/killring.nvim) ![](https://img.shields.io/github/stars/sunesimonsen/killring.nvim) ![](https://img.shields.io/github/last-commit/sunesimonsen/killring.nvim) ![](https://img.shields.io/github/commit-activity/y/sunesimonsen/killring.nvim)
 
 ### Mac
 


### PR DESCRIPTION
|URL|Category|Reason|
|---|---|---|
|https://github.com/0xferrous/eth.nvim|New Category (Blockchain / Ethereum Integration)|eth.nvim is a Neovim plugin designed to integrate Ethereum blockchain development workflows directly into the editor, enabling tasks like smart contract interaction and blockchain querying, which fits best under a new category focused on blockchain or Ethereum tools.
|https://github.com/9f2c/nvim-stream-completion|Auto Completion / Auto Completion Plugin / Made in Lua|It is a Neovim plugin written in Lua that focuses on streaming completion, integrating AI-driven code completions in real-time, fitting well under auto-completion plugins made in Lua.|
|https://github.com/CaetanoGenete/python-tools.nvim|Python / Development Tools|The plugin provides utilities and enhancements specifically designed for Python development in Neovim, such as running tests and managing Python-related tasks, fitting well into Python development tooling.
|https://github.com/Ricie23/dyslexic-swap.nvim|Textobject / Swap|The plugin provides functionality to swap characters or text segments in a way that helps dyslexic users, aligning with text object swapping features seen in other swap plugins.|
|https://github.com/avifenesh/claucode.nvim|AI Coding / Claude Code|The plugin integrates Anthropic's Claude API into Neovim for AI-assisted coding, matching the category of similar Claude-based AI coding tools.|
|https://github.com/cenkalti/format-command-line.nvim|Formatter|The plugin formats command-line input in Neovim to improve readability, fitting best under Formatter category as it focuses on code or command formatting.|
|https://github.com/ltfiend/nvim-rfc-editor|RFC|The plugin is designed specifically for editing RFC documents in Neovim, similar to other RFC-related plugins, focusing on managing and editing RFC text.|
|https://github.com/neet-007/rfc-view.nvim|RFC|The plugin provides an interface to view and browse RFC documents inside Neovim, aligning with plugins categorized under RFC for reading and referencing RFCs.|
|https://github.com/pittcat/macos-screenshot.nvim|Image / Screenshot|This plugin provides a way to take screenshots on macOS integrated with Neovim, fitting the Image / Screenshot category used for similar screenshot tools.|
|https://github.com/sheikhevan/luhmann.nvim|Note Taking / Zettelkasten|The plugin is designed for managing notes in the style of the Zettelkasten method, inspired by Niklas Luhmann's note-taking system, making it fit clearly under the Note Taking / Zettelkasten category.|
|https://github.com/sunesimonsen/killring.nvim|Paste / Cyclic paste|The plugin manages a kill ring (clipboard history) allowing users to cycle through past yanks and paste them, fitting the cyclic paste category.|
