### PR TITLE
Add

### DIFF
--- a/ai.md
+++ b/ai.md
@@ -536,6 +536,7 @@
 - [heilgar/nochat.nvim](https://github.com/heilgar/nochat.nvim) ![](https://img.shields.io/github/stars/heilgar/nochat.nvim) ![](https://img.shields.io/github/last-commit/heilgar/nochat.nvim) ![](https://img.shields.io/github/commit-activity/y/heilgar/nochat.nvim)
 - [tsukimizake/prompt-in-buf.nvim](https://github.com/tsukimizake/prompt-in-buf.nvim) ![](https://img.shields.io/github/stars/tsukimizake/prompt-in-buf.nvim) ![](https://img.shields.io/github/last-commit/tsukimizake/prompt-in-buf.nvim) ![](https://img.shields.io/github/commit-activity/y/tsukimizake/prompt-in-buf.nvim)
 - [kiminandayo19/nvim-ai](https://github.com/kiminandayo19/nvim-ai) ![](https://img.shields.io/github/stars/kiminandayo19/nvim-ai) ![](https://img.shields.io/github/last-commit/kiminandayo19/nvim-ai) ![](https://img.shields.io/github/commit-activity/y/kiminandayo19/nvim-ai)
+- [mikey-arch/askcat.nvim](https://github.com/mikey-arch/askcat.nvim) ![](https://img.shields.io/github/stars/mikey-arch/askcat.nvim) ![](https://img.shields.io/github/last-commit/mikey-arch/askcat.nvim) ![](https://img.shields.io/github/commit-activity/y/mikey-arch/askcat.nvim)
 
 ## AI Terminal
 

--- a/buffer.md
+++ b/buffer.md
@@ -113,6 +113,7 @@
 - [Dkendal/nvim-alternate](https://github.com/Dkendal/nvim-alternate) ![](https://img.shields.io/github/stars/Dkendal/nvim-alternate) ![](https://img.shields.io/github/last-commit/Dkendal/nvim-alternate) ![](https://img.shields.io/github/commit-activity/y/Dkendal/nvim-alternate)
 - [herisetiawan00/jtt.nvim](https://github.com/herisetiawan00/jtt.nvim) ![](https://img.shields.io/github/stars/herisetiawan00/jtt.nvim) ![](https://img.shields.io/github/last-commit/herisetiawan00/jtt.nvim) ![](https://img.shields.io/github/commit-activity/y/herisetiawan00/jtt.nvim)
 - [samr/fileflip.nvim](https://github.com/samr/fileflip.nvim) ![](https://img.shields.io/github/stars/samr/fileflip.nvim) ![](https://img.shields.io/github/last-commit/samr/fileflip.nvim) ![](https://img.shields.io/github/commit-activity/y/samr/fileflip.nvim)
+- [devansh08/alt-tab.nvim](https://github.com/devansh08/alt-tab.nvim) ![](https://img.shields.io/github/stars/devansh08/alt-tab.nvim) ![](https://img.shields.io/github/last-commit/devansh08/alt-tab.nvim) ![](https://img.shields.io/github/commit-activity/y/devansh08/alt-tab.nvim)
 
 ### Buffer Management
 
@@ -198,6 +199,7 @@
 - [54322/mru.nvim](https://github.com/54322/mru.nvim) ![](https://img.shields.io/github/stars/54322/mru.nvim) ![](https://img.shields.io/github/last-commit/54322/mru.nvim) ![](https://img.shields.io/github/commit-activity/y/54322/mru.nvim)
 - [kj-1809/previous-buffer.nvim](https://github.com/kj-1809/previous-buffer.nvim) ![](https://img.shields.io/github/stars/kj-1809/previous-buffer.nvim) ![](https://img.shields.io/github/last-commit/kj-1809/previous-buffer.nvim) ![](https://img.shields.io/github/commit-activity/y/kj-1809/previous-buffer.nvim)
 - [TorrezMN/nvim_recent_file_picker.nvim](https://github.com/TorrezMN/nvim_recent_file_picker.nvim) ![](https://img.shields.io/github/stars/TorrezMN/nvim_recent_file_picker.nvim) ![](https://img.shields.io/github/last-commit/TorrezMN/nvim_recent_file_picker.nvim) ![](https://img.shields.io/github/commit-activity/y/TorrezMN/nvim_recent_file_picker.nvim)
+- [pe1te3son/prev-buffer.nvim](https://github.com/pe1te3son/prev-buffer.nvim) ![](https://img.shields.io/github/stars/pe1te3son/prev-buffer.nvim) ![](https://img.shields.io/github/last-commit/pe1te3son/prev-buffer.nvim) ![](https://img.shields.io/github/commit-activity/y/pe1te3son/prev-buffer.nvim)
 
 ##### remote open
 

--- a/git-github.md
+++ b/git-github.md
@@ -241,6 +241,8 @@
 - [ethanamaher/better-git-blame.nvim](https://github.com/ethanamaher/better-git-blame.nvim) ![](https://img.shields.io/github/stars/ethanamaher/better-git-blame.nvim) ![](https://img.shields.io/github/last-commit/ethanamaher/better-git-blame.nvim) ![](https://img.shields.io/github/commit-activity/y/ethanamaher/better-git-blame.nvim)
 - [art-vasilyev/gerrit-blame.nvim](https://github.com/art-vasilyev/gerrit-blame.nvim) ![](https://img.shields.io/github/stars/art-vasilyev/gerrit-blame.nvim) ![](https://img.shields.io/github/last-commit/art-vasilyev/gerrit-blame.nvim) ![](https://img.shields.io/github/commit-activity/y/art-vasilyev/gerrit-blame.nvim)
 - [yt20chill/inline_git_blame.nvim](https://github.com/yt20chill/inline_git_blame.nvim) ![](https://img.shields.io/github/stars/yt20chill/inline_git_blame.nvim) ![](https://img.shields.io/github/last-commit/yt20chill/inline_git_blame.nvim) ![](https://img.shields.io/github/commit-activity/y/yt20chill/inline_git_blame.nvim)
+- [tmybsv/blame.nvim](https://github.com/tmybsv/blame.nvim) ![](https://img.shields.io/github/stars/tmybsv/blame.nvim) ![](https://img.shields.io/github/last-commit/tmybsv/blame.nvim) ![](https://img.shields.io/github/commit-activity/y/tmybsv/blame.nvim)
+- [va-ji/git_snoop.nvim](https://github.com/va-ji/git_snoop.nvim) ![](https://img.shields.io/github/stars/va-ji/git_snoop.nvim) ![](https://img.shields.io/github/last-commit/va-ji/git_snoop.nvim) ![](https://img.shields.io/github/commit-activity/y/va-ji/git_snoop.nvim)
 
 ### git log
 

--- a/jump.md
+++ b/jump.md
@@ -26,6 +26,7 @@
 - [lululau/telescope-autojump.nvim](https://github.com/lululau/telescope-autojump.nvim) ![](https://img.shields.io/github/stars/lululau/telescope-autojump.nvim) ![](https://img.shields.io/github/last-commit/lululau/telescope-autojump.nvim) ![](https://img.shields.io/github/commit-activity/y/lululau/telescope-autojump.nvim)
 - [pinbraerts/swipe.nvim](https://github.com/pinbraerts/swipe.nvim) ![](https://img.shields.io/github/stars/pinbraerts/swipe.nvim) ![](https://img.shields.io/github/last-commit/pinbraerts/swipe.nvim) ![](https://img.shields.io/github/commit-activity/y/pinbraerts/swipe.nvim)
 - [krmmzs/jump-beacon.nvim](https://github.com/krmmzs/jump-beacon.nvim) ![](https://img.shields.io/github/stars/krmmzs/jump-beacon.nvim) ![](https://img.shields.io/github/last-commit/krmmzs/jump-beacon.nvim) ![](https://img.shields.io/github/commit-activity/y/krmmzs/jump-beacon.nvim)
+- [tiwari-krishna/nvHopper.nvim](https://github.com/tiwari-krishna/nvHopper.nvim) ![](https://img.shields.io/github/stars/tiwari-krishna/nvHopper.nvim) ![](https://img.shields.io/github/last-commit/tiwari-krishna/nvHopper.nvim) ![](https://img.shields.io/github/commit-activity/y/tiwari-krishna/nvHopper.nvim)
 
 ### Error
 

--- a/note-taking.md
+++ b/note-taking.md
@@ -189,6 +189,7 @@
 - [antoniofontaneti/todo.nvim](https://github.com/antoniofontaneti/todo.nvim) ![](https://img.shields.io/github/stars/antoniofontaneti/todo.nvim) ![](https://img.shields.io/github/last-commit/antoniofontaneti/todo.nvim) ![](https://img.shields.io/github/commit-activity/y/antoniofontaneti/todo.nvim)
 - [M0rtamor/todo.nvim](https://github.com/M0rtamor/todo.nvim) ![](https://img.shields.io/github/stars/M0rtamor/todo.nvim) ![](https://img.shields.io/github/last-commit/M0rtamor/todo.nvim) ![](https://img.shields.io/github/commit-activity/y/M0rtamor/todo.nvim)
 - [TimothyGCY/todo.nvim](https://github.com/TimothyGCY/todo.nvim) ![](https://img.shields.io/github/stars/TimothyGCY/todo.nvim) ![](https://img.shields.io/github/last-commit/TimothyGCY/todo.nvim) ![](https://img.shields.io/github/commit-activity/y/TimothyGCY/todo.nvim)
+- [maheshbansod/todo-marker.nvim](https://github.com/maheshbansod/todo-marker.nvim) ![](https://img.shields.io/github/stars/maheshbansod/todo-marker.nvim) ![](https://img.shields.io/github/last-commit/maheshbansod/todo-marker.nvim) ![](https://img.shields.io/github/commit-activity/y/maheshbansod/todo-marker.nvim)
 
 #### Taskwarrior
 

--- a/plugin-manager.md
+++ b/plugin-manager.md
@@ -46,6 +46,7 @@
 - [MisanthropicBit/parcel.nvim](https://github.com/MisanthropicBit/parcel.nvim) ![](https://img.shields.io/github/stars/MisanthropicBit/parcel.nvim) ![](https://img.shields.io/github/last-commit/MisanthropicBit/parcel.nvim) ![](https://img.shields.io/github/commit-activity/y/MisanthropicBit/parcel.nvim)
 - [lulkien/packoff.nvim](https://github.com/lulkien/packoff.nvim) ![](https://img.shields.io/github/stars/lulkien/packoff.nvim) ![](https://img.shields.io/github/last-commit/lulkien/packoff.nvim) ![](https://img.shields.io/github/commit-activity/y/lulkien/packoff.nvim)
 - [wsdjeg/nvim-plug](https://github.com/wsdjeg/nvim-plug) ![](https://img.shields.io/github/stars/wsdjeg/nvim-plug) ![](https://img.shields.io/github/last-commit/wsdjeg/nvim-plug) ![](https://img.shields.io/github/commit-activity/y/wsdjeg/nvim-plug)
+- [piersolenski/plugin-addict.nvim](https://github.com/piersolenski/plugin-addict.nvim) ![](https://img.shields.io/github/stars/piersolenski/plugin-addict.nvim) ![](https://img.shields.io/github/last-commit/piersolenski/plugin-addict.nvim) ![](https://img.shields.io/github/commit-activity/y/piersolenski/plugin-addict.nvim)
 
 ### Use builtin package feature
 

--- a/python.md
+++ b/python.md
@@ -116,6 +116,7 @@
 ### Profiler
 
 - [Matze-isses/py-profiler.nvim](https://github.com/Matze-isses/py-profiler.nvim) ![](https://img.shields.io/github/stars/Matze-isses/py-profiler.nvim) ![](https://img.shields.io/github/last-commit/Matze-isses/py-profiler.nvim) ![](https://img.shields.io/github/commit-activity/y/Matze-isses/py-profiler.nvim)
+- [cyprienhm/python-profiler.nvim](https://github.com/cyprienhm/python-profiler.nvim) ![](https://img.shields.io/github/stars/cyprienhm/python-profiler.nvim) ![](https://img.shields.io/github/last-commit/cyprienhm/python-profiler.nvim) ![](https://img.shields.io/github/commit-activity/y/cyprienhm/python-profiler.nvim)
 
 ## LSP
 

--- a/readme.md
+++ b/readme.md
@@ -375,6 +375,7 @@
 - [shrynx/line-numbers.nvim](https://github.com/shrynx/line-numbers.nvim) ![](https://img.shields.io/github/stars/shrynx/line-numbers.nvim) ![](https://img.shields.io/github/last-commit/shrynx/line-numbers.nvim) ![](https://img.shields.io/github/commit-activity/y/shrynx/line-numbers.nvim)
 - [teial/relvirt.nvim](https://github.com/teial/relvirt.nvim) ![](https://img.shields.io/github/stars/teial/relvirt.nvim) ![](https://img.shields.io/github/last-commit/teial/relvirt.nvim) ![](https://img.shields.io/github/commit-activity/y/teial/relvirt.nvim)
 - [am2b/smartnumber.nvim](https://github.com/am2b/smartnumber.nvim) ![](https://img.shields.io/github/stars/am2b/smartnumber.nvim) ![](https://img.shields.io/github/last-commit/am2b/smartnumber.nvim) ![](https://img.shields.io/github/commit-activity/y/am2b/smartnumber.nvim)
+- [niels4/number-scrubber.nvim](https://github.com/niels4/number-scrubber.nvim) ![](https://img.shields.io/github/stars/niels4/number-scrubber.nvim) ![](https://img.shields.io/github/last-commit/niels4/number-scrubber.nvim) ![](https://img.shields.io/github/commit-activity/y/niels4/number-scrubber.nvim)
 
 ### [Mark](./mark.md)
 


### PR DESCRIPTION
|URL|Category|Reason|
|---|---|---|
|https://github.com/cyprienhm/python-profiler.nvim|Python / Profiler|The plugin is designed to profile Python code within Neovim, helping users analyze performance, fitting well in the Python / Profiler category.|
|https://github.com/devansh08/alt-tab.nvim|Buffer / Other Buffer Switcher|alt-tab.nvim is a Neovim plugin that allows users to switch between buffers easily using an interface similar to the Alt-Tab functionality in operating systems, fitting best into buffer switching utilities.|
|https://github.com/maheshbansod/todo-marker.nvim|Note Taking / ToDo|The plugin highlights TODO comments and marks in source code, focusing on managing and visualizing TODO items within files, fitting well within Note Taking / ToDo categories.|
|https://github.com/mikey-arch/askcat.nvim|Chat|askcat.nvim is a Neovim plugin that integrates with OpenAI's ChatGPT to provide chat-based interactions within the editor, facilitating conversational AI assistance similar to other chat-focused plugins.|
|https://github.com/niels4/number-scrubber.nvim|Other Standard Feature Enhancement / Number|The plugin is designed to enhance the handling of numbers in Neovim, such as incrementing, decrementing, or modifying numbers inline, fitting well within the number-related feature enhancement category.|
|https://github.com/pe1te3son/prev-buffer.nvim|Buffer / Buffer Management / open / recent file|The plugin allows quick switching to the previous buffer, which fits into buffer management focused on navigating between open or recent files.|
|https://github.com/piersolenski/plugin-addict.nvim|Plugin Manager / Add runtime path (vim-plug like)|plugin-addict.nvim is a Neovim plugin manager that allows managing plugins by adding them to the runtime path in a manner similar to vim-plug.|
|https://github.com/tiwari-krishna/nvHopper.nvim|Jump|nvHopper.nvim is a Neovim plugin designed for quick navigation by allowing users to instantly jump to any visible word in the buffer using minimal keystrokes, which fits well in the Jump category.
|https://github.com/tmybsv/blame.nvim|Git / git blame|The plugin provides git blame information inline in Neovim, similar to other git blame plugins listed, making "Git / git blame" the most appropriate category.|
|https://github.com/va-ji/git_snoop.nvim|Git / git blame|The plugin git_snoop.nvim provides inline Git blame information, showing the author and commit details for the current line in Neovim, fitting well in the Git blame category.
