### PR TITLE
Add

### DIFF
--- a/checker.md
+++ b/checker.md
@@ -23,3 +23,4 @@
 ## checkhealth
 
 - [Davidyz/executable-checker.nvim](https://github.com/Davidyz/executable-checker.nvim) ![](https://img.shields.io/github/stars/Davidyz/executable-checker.nvim) ![](https://img.shields.io/github/last-commit/Davidyz/executable-checker.nvim) ![](https://img.shields.io/github/commit-activity/y/Davidyz/executable-checker.nvim)
+- [Luiz-Filipe26/health-check-filter.nvim](https://github.com/Luiz-Filipe26/health-check-filter.nvim) ![](https://img.shields.io/github/stars/Luiz-Filipe26/health-check-filter.nvim) ![](https://img.shields.io/github/last-commit/Luiz-Filipe26/health-check-filter.nvim) ![](https://img.shields.io/github/commit-activity/y/Luiz-Filipe26/health-check-filter.nvim)

--- a/lsp.md
+++ b/lsp.md
@@ -131,6 +131,7 @@
 - [oribarilan/lensline.nvim](https://github.com/oribarilan/lensline.nvim) ![](https://img.shields.io/github/stars/oribarilan/lensline.nvim) ![](https://img.shields.io/github/last-commit/oribarilan/lensline.nvim) ![](https://img.shields.io/github/commit-activity/y/oribarilan/lensline.nvim)
 - [coreyb-git/virtlines-delay.nvim](https://github.com/coreyb-git/virtlines-delay.nvim) ![](https://img.shields.io/github/stars/coreyb-git/virtlines-delay.nvim) ![](https://img.shields.io/github/last-commit/coreyb-git/virtlines-delay.nvim) ![](https://img.shields.io/github/commit-activity/y/coreyb-git/virtlines-delay.nvim)
 
+
 ##### Diagnostics goto
 
 - [mizlan/delimited.nvim](https://github.com/mizlan/delimited.nvim) ![](https://img.shields.io/github/stars/mizlan/delimited.nvim) ![](https://img.shields.io/github/last-commit/mizlan/delimited.nvim) ![](https://img.shields.io/github/commit-activity/y/mizlan/delimited.nvim)

--- a/statusline.md
+++ b/statusline.md
@@ -98,6 +98,7 @@
 ### Statusline component
 
 - [b0o/incline.nvim](https://github.com/b0o/incline.nvim) ![](https://img.shields.io/github/stars/b0o/incline.nvim) ![](https://img.shields.io/github/last-commit/b0o/incline.nvim) ![](https://img.shields.io/github/commit-activity/y/b0o/incline.nvim)
+- [julien-me/milestone.nvim](https://github.com/julien-me/milestone.nvim) ![](https://img.shields.io/github/stars/julien-me/milestone.nvim) ![](https://img.shields.io/github/last-commit/julien-me/milestone.nvim) ![](https://img.shields.io/github/commit-activity/y/julien-me/milestone.nvim)
 - [erhickey/diagline-nvim](https://github.com/erhickey/diagline-nvim) ![](https://img.shields.io/github/stars/erhickey/diagline-nvim) ![](https://img.shields.io/github/last-commit/erhickey/diagline-nvim) ![](https://img.shields.io/github/commit-activity/y/erhickey/diagline-nvim)
 - [oncomouse/czs.nvim](https://github.com/oncomouse/czs.nvim) ![](https://img.shields.io/github/stars/oncomouse/czs.nvim) ![](https://img.shields.io/github/last-commit/oncomouse/czs.nvim) ![](https://img.shields.io/github/commit-activity/y/oncomouse/czs.nvim)
 - [roobert/statusline-action-hints.nvim](https://github.com/roobert/statusline-action-hints.nvim) ![](https://img.shields.io/github/stars/roobert/statusline-action-hints.nvim) ![](https://img.shields.io/github/last-commit/roobert/statusline-action-hints.nvim) ![](https://img.shields.io/github/commit-activity/y/roobert/statusline-action-hints.nvim)


### PR DESCRIPTION
|URL|Category|Reason|
|---|---|---|
|https://github.com/Luiz-Filipe26/health-check-filter.nvim|Checker / checkhealth|The plugin filters messages shown by `:checkhealth`, not LSP diagnostics. It specifically targets Neovim health output, so it belongs under checkhealth tools rather than LSP Diagnostics.|
|https://github.com/QuantEcon/myst-markdown-tree-sitter.nvim|Documentation / Markdown / Syntax Highlighting|Provides Tree-sitter support for the MyST Markdown dialect, enhancing Markdown syntax highlighting in Neovim. Fits best with markdown-focused documentation and syntax tooling.|
|https://github.com/StellarDeca/winime.nvim|Integration Apps / IME|Integrates Windows IME with Neovim, improving input method handling. This aligns with IME integrations listed under Integration Apps.|
|https://github.com/afkale/wswitcher.nvim|Convert / Convert Word|Adds word switching/toggling operations, matching other “Convert Word” utilities that change tokens or word forms.|
|https://github.com/cosmas375/nvim-buffer-sorter|Buffer / Buffer Management|Provides sorting and organization of buffers, which is buffer management functionality (not display-only or picker-specific).|
|https://github.com/hmgle/nvim-cat|Syntax / Colorizer|A CLI viewer powered by Neovim’s syntax engine; its core function is syntax colorization/highlighting, aligning with colorizer tools.|
|https://github.com/julien-me/milestone.nvim|Statusline / Statusline component|Supplies a statusline component that shows progress milestones. It’s a component rather than a full statusline framework, so it belongs under Statusline component.|
|https://github.com/phush0/llama.nvim|AI / Llama|Integrates LLaMA-family models into Neovim for AI-assisted coding, matching the dedicated Llama section.|
|https://github.com/rkb121541/floaterminal.nvim|Terminal / Open|Opens and manages floating terminal windows inside Neovim, matching the “open” terminal category.|
|https://github.com/rohsins/nvim-floterm|Terminal / Open|Provides floating terminal windows within Neovim, consistent with other open/floating terminal plugins.|
|https://github.com/theStrangeAdventurer/ai_memory.nvim|AI Assistant / Context Memory|Adds persistent/context memory for AI assistants in Neovim, enabling recall of past interactions; fits an AI assistant memory category.|
|https://github.com/viligante8/maccy.nvim|Paste / Mac|Integrates the Maccy clipboard manager on macOS for paste/clipboard history, which fits macOS-specific paste utilities.|

