### PR TITLE
Add

### DIFF
--- a/ai.md
+++ b/ai.md
@@ -348,6 +348,7 @@
 - [avifenesh/claucode.nvim](https://github.com/avifenesh/claucode.nvim) ![](https://img.shields.io/github/stars/avifenesh/claucode.nvim) ![](https://img.shields.io/github/last-commit/avifenesh/claucode.nvim) ![](https://img.shields.io/github/commit-activity/y/avifenesh/claucode.nvim)
 - [SouhailBlmn/claude-code.nvim](https://github.com/SouhailBlmn/claude-code.nvim) ![](https://img.shields.io/github/stars/SouhailBlmn/claude-code.nvim) ![](https://img.shields.io/github/last-commit/SouhailBlmn/claude-code.nvim) ![](https://img.shields.io/github/commit-activity/y/SouhailBlmn/claude-code.nvim)
 - [kylesnowschwartz/claude-code-tui.nvim](https://github.com/kylesnowschwartz/claude-code-tui.nvim) ![](https://img.shields.io/github/stars/kylesnowschwartz/claude-code-tui.nvim) ![](https://img.shields.io/github/last-commit/kylesnowschwartz/claude-code-tui.nvim) ![](https://img.shields.io/github/commit-activity/y/kylesnowschwartz/claude-code-tui.nvim)
+- [rhnvrm/nvim-claudecode-mcp](https://github.com/rhnvrm/nvim-claudecode-mcp) ![](https://img.shields.io/github/stars/rhnvrm/nvim-claudecode-mcp) ![](https://img.shields.io/github/last-commit/rhnvrm/nvim-claudecode-mcp) ![](https://img.shields.io/github/commit-activity/y/rhnvrm/nvim-claudecode-mcp)
 
 ### Amazon Q
 

--- a/ai.md
+++ b/ai.md
@@ -347,8 +347,7 @@
 - [qtnx/multiclaudecode.nvim](https://github.com/qtnx/multiclaudecode.nvim) ![](https://img.shields.io/github/stars/qtnx/multiclaudecode.nvim) ![](https://img.shields.io/github/last-commit/qtnx/multiclaudecode.nvim) ![](https://img.shields.io/github/commit-activity/y/qtnx/multiclaudecode.nvim)
 - [avifenesh/claucode.nvim](https://github.com/avifenesh/claucode.nvim) ![](https://img.shields.io/github/stars/avifenesh/claucode.nvim) ![](https://img.shields.io/github/last-commit/avifenesh/claucode.nvim) ![](https://img.shields.io/github/commit-activity/y/avifenesh/claucode.nvim)
 - [SouhailBlmn/claude-code.nvim](https://github.com/SouhailBlmn/claude-code.nvim) ![](https://img.shields.io/github/stars/SouhailBlmn/claude-code.nvim) ![](https://img.shields.io/github/last-commit/SouhailBlmn/claude-code.nvim) ![](https://img.shields.io/github/commit-activity/y/SouhailBlmn/claude-code.nvim)
-- [kylesnowschwartz/claude-code-tui.nvim](https://github.com/kylesnowschwartz/claude-code-tui.nvim) ![](https://img.shields.io/github/stars/kylesnowschwartz/claude-code-tui.nvim) ![](https://img.shields.io/github/last-commit/kylesnowschwartz/claude-code-tui.nvim) ![](https://img.shields.io/github/commit-activity/y/kylesnowschwartz/claude-code-tui.nvim)
-- [rhnvrm/nvim-claudecode-mcp](https://github.com/rhnvrm/nvim-claudecode-mcp) ![](https://img.shields.io/github/stars/rhnvrm/nvim-claudecode-mcp) ![](https://img.shields.io/github/last-commit/rhnvrm/nvim-claudecode-mcp) ![](https://img.shields.io/github/commit-activity/y/rhnvrm/nvim-claudecode-mcp)
+ - [kylesnowschwartz/claude-code-tui.nvim](https://github.com/kylesnowschwartz/claude-code-tui.nvim) ![](https://img.shields.io/github/stars/kylesnowschwartz/claude-code-tui.nvim) ![](https://img.shields.io/github/last-commit/kylesnowschwartz/claude-code-tui.nvim) ![](https://img.shields.io/github/commit-activity/y/kylesnowschwartz/claude-code-tui.nvim)
 
 ### Amazon Q
 
@@ -632,6 +631,7 @@
 - [thatguyinabeanie/todo-mcp.nvim](https://github.com/thatguyinabeanie/todo-mcp.nvim) ![](https://img.shields.io/github/stars/thatguyinabeanie/todo-mcp.nvim) ![](https://img.shields.io/github/last-commit/thatguyinabeanie/todo-mcp.nvim) ![](https://img.shields.io/github/commit-activity/y/thatguyinabeanie/todo-mcp.nvim)
 - [guill/mcpdap.nvim](https://github.com/guill/mcpdap.nvim) ![](https://img.shields.io/github/stars/guill/mcpdap.nvim) ![](https://img.shields.io/github/last-commit/guill/mcpdap.nvim) ![](https://img.shields.io/github/commit-activity/y/guill/mcpdap.nvim)
 - [linw1995/nvim-mcp](https://github.com/linw1995/nvim-mcp) ![](https://img.shields.io/github/stars/linw1995/nvim-mcp) ![](https://img.shields.io/github/last-commit/linw1995/nvim-mcp) ![](https://img.shields.io/github/commit-activity/y/linw1995/nvim-mcp)
+ - [rhnvrm/nvim-claudecode-mcp](https://github.com/rhnvrm/nvim-claudecode-mcp) ![](https://img.shields.io/github/stars/rhnvrm/nvim-claudecode-mcp) ![](https://img.shields.io/github/last-commit/rhnvrm/nvim-claudecode-mcp) ![](https://img.shields.io/github/commit-activity/y/rhnvrm/nvim-claudecode-mcp)
 
 ## ignore
 

--- a/documentation.md
+++ b/documentation.md
@@ -389,6 +389,7 @@
 - [SebastiaanBooman/botanist.nvim](https://github.com/SebastiaanBooman/botanist.nvim) ![](https://img.shields.io/github/stars/SebastiaanBooman/botanist.nvim) ![](https://img.shields.io/github/last-commit/SebastiaanBooman/botanist.nvim) ![](https://img.shields.io/github/commit-activity/y/SebastiaanBooman/botanist.nvim)
 - [Gabz-Araujo/plantuml.nvim](https://github.com/Gabz-Araujo/plantuml.nvim) ![](https://img.shields.io/github/stars/Gabz-Araujo/plantuml.nvim) ![](https://img.shields.io/github/last-commit/Gabz-Araujo/plantuml.nvim) ![](https://img.shields.io/github/commit-activity/y/Gabz-Araujo/plantuml.nvim)
 - [tobias-edwards/plantuml-preview.nvim](https://github.com/tobias-edwards/plantuml-preview.nvim) ![](https://img.shields.io/github/stars/tobias-edwards/plantuml-preview.nvim) ![](https://img.shields.io/github/last-commit/tobias-edwards/plantuml-preview.nvim) ![](https://img.shields.io/github/commit-activity/y/tobias-edwards/plantuml-preview.nvim)
+- [charlesnicholson/plantuml.nvim](https://github.com/charlesnicholson/plantuml.nvim) ![](https://img.shields.io/github/stars/charlesnicholson/plantuml.nvim) ![](https://img.shields.io/github/last-commit/charlesnicholson/plantuml.nvim) ![](https://img.shields.io/github/commit-activity/y/charlesnicholson/plantuml.nvim)
 
 ### Mermaid
 

--- a/git-github.md
+++ b/git-github.md
@@ -422,6 +422,7 @@
 - [l3d00m/jj-signs.nvim](https://github.com/l3d00m/jj-signs.nvim) ![](https://img.shields.io/github/stars/l3d00m/jj-signs.nvim) ![](https://img.shields.io/github/last-commit/l3d00m/jj-signs.nvim) ![](https://img.shields.io/github/commit-activity/y/l3d00m/jj-signs.nvim)
 - [tilupe/submission.nvim](https://github.com/tilupe/submission.nvim) ![](https://img.shields.io/github/stars/tilupe/submission.nvim) ![](https://img.shields.io/github/last-commit/tilupe/submission.nvim) ![](https://img.shields.io/github/commit-activity/y/tilupe/submission.nvim)
 - [Charlie-83/jjsigns.nvim](https://github.com/Charlie-83/jjsigns.nvim) ![](https://img.shields.io/github/stars/Charlie-83/jjsigns.nvim) ![](https://img.shields.io/github/last-commit/Charlie-83/jjsigns.nvim) ![](https://img.shields.io/github/commit-activity/y/Charlie-83/jjsigns.nvim)
+- [Glhou/lazyjj.nvim](https://github.com/Glhou/lazyjj.nvim) ![](https://img.shields.io/github/stars/Glhou/lazyjj.nvim) ![](https://img.shields.io/github/last-commit/Glhou/lazyjj.nvim) ![](https://img.shields.io/github/commit-activity/y/Glhou/lazyjj.nvim)
 
 ### diff
 

--- a/language-specific.md
+++ b/language-specific.md
@@ -693,6 +693,7 @@
 #### Beancount
 
 - [crispgm/cmp-beancount](https://github.com/crispgm/cmp-beancount) ![](https://img.shields.io/github/stars/crispgm/cmp-beancount) ![](https://img.shields.io/github/last-commit/crispgm/cmp-beancount) ![](https://img.shields.io/github/commit-activity/y/crispgm/cmp-beancount)
+- [hxueh/beancount.nvim](https://github.com/hxueh/beancount.nvim) ![](https://img.shields.io/github/stars/hxueh/beancount.nvim) ![](https://img.shields.io/github/last-commit/hxueh/beancount.nvim) ![](https://img.shields.io/github/commit-activity/y/hxueh/beancount.nvim)
 
 #### incc
 

--- a/note-taking.md
+++ b/note-taking.md
@@ -86,6 +86,7 @@
 - [y3owk1n/dotmd.nvim](https://github.com/y3owk1n/dotmd.nvim) ![](https://img.shields.io/github/stars/y3owk1n/dotmd.nvim) ![](https://img.shields.io/github/last-commit/y3owk1n/dotmd.nvim) ![](https://img.shields.io/github/commit-activity/y/y3owk1n/dotmd.nvim)
 - [MistbornOne/better-tasks.nvim](https://github.com/MistbornOne/better-tasks.nvim) ![](https://img.shields.io/github/stars/MistbornOne/better-tasks.nvim) ![](https://img.shields.io/github/last-commit/MistbornOne/better-tasks.nvim) ![](https://img.shields.io/github/commit-activity/y/MistbornOne/better-tasks.nvim)
 - [xpcoffee/nvim-markdown-notes](https://github.com/xpcoffee/nvim-markdown-notes) ![](https://img.shields.io/github/stars/xpcoffee/nvim-markdown-notes) ![](https://img.shields.io/github/last-commit/xpcoffee/nvim-markdown-notes) ![](https://img.shields.io/github/commit-activity/y/xpcoffee/nvim-markdown-notes)
+- [notedownorg/notedown.nvim](https://github.com/notedownorg/notedown.nvim) ![](https://img.shields.io/github/stars/notedownorg/notedown.nvim) ![](https://img.shields.io/github/last-commit/notedownorg/notedown.nvim) ![](https://img.shields.io/github/commit-activity/y/notedownorg/notedown.nvim)
 
 ### ToDo
 

--- a/translate.md
+++ b/translate.md
@@ -28,6 +28,7 @@
 - [ubuygold/nvim-translator](https://github.com/ubuygold/nvim-translator) ![](https://img.shields.io/github/stars/ubuygold/nvim-translator) ![](https://img.shields.io/github/last-commit/ubuygold/nvim-translator) ![](https://img.shields.io/github/commit-activity/y/ubuygold/nvim-translator)
 - [Lingshinx/trans-hover.nvim](https://github.com/Lingshinx/trans-hover.nvim) ![](https://img.shields.io/github/stars/Lingshinx/trans-hover.nvim) ![](https://img.shields.io/github/last-commit/Lingshinx/trans-hover.nvim) ![](https://img.shields.io/github/commit-activity/y/Lingshinx/trans-hover.nvim)
 - [RunnyC/translator.nvim](https://github.com/RunnyC/translator.nvim) ![](https://img.shields.io/github/stars/RunnyC/translator.nvim) ![](https://img.shields.io/github/last-commit/RunnyC/translator.nvim) ![](https://img.shields.io/github/commit-activity/y/RunnyC/translator.nvim)
+- [cxwx/argosTrans.nvim](https://github.com/cxwx/argosTrans.nvim) ![](https://img.shields.io/github/stars/cxwx/argosTrans.nvim) ![](https://img.shields.io/github/last-commit/cxwx/argosTrans.nvim) ![](https://img.shields.io/github/commit-activity/y/cxwx/argosTrans.nvim)
 
 ## i18n
 


### PR DESCRIPTION
|URL|Category|Reason|
|---|---|---|
|https://github.com/Glhou/lazyjj.nvim|Jujutsu(jj)|Neovim integration for the Jujutsu (jj) VCS; fits under Git > Jujutsu(jj) alongside other jj tools.|
|https://github.com/charlesnicholson/plantuml.nvim|Documentation / PlantUML|Provides PlantUML diagram preview via a local server and live updates; belongs with other PlantUML documentation utilities.|
|https://github.com/cxwx/argosTrans.nvim|Translate|Implements in-editor translation using argos-translate with visual/insert modes; matches other translation plugins in translate.md.|
|https://github.com/hxueh/beancount.nvim|Language specific / Beancount|Full Beancount support (syntax, diagnostics, completion, formatting, snippets); placed under the Beancount subsection of language-specific.md.|
|https://github.com/notedownorg/notedown.nvim|Note Taking / Markdown|Note-taking plugin for Notedown Flavored Markdown with LSP integration; fits the Markdown subsection of note-taking.md.|
|https://github.com/rhnvrm/nvim-claudecode-mcp|AI Coding / Model Context Protocol(MCP)|Runs an MCP server for editor interaction via WebSocket/JSON-RPC; better categorized under the MCP section rather than Claude Code IDE clients.|

