### PR TITLE
Improve add skill

### DIFF
--- a/.codex/skills/add/references/PLACEMENT_RULES.md
+++ b/.codex/skills/add/references/PLACEMENT_RULES.md
@@ -7,6 +7,7 @@ Use these rules before choosing a category from `SECTION.md`.
 - Fuzzy-finder sources, picker extensions, and completion sources should be placed in their related domain category, not in `fuzzy-finder.md` or `completion.md`, unless the plugin primarily changes the fuzzy-finder or completion framework itself.
 - Put a Git-related Telescope, fzf-lua, Snacks, or other picker extension in `git-github.md / Git`.
 - Put an LSP-related completion source in `lsp.md`, using the most specific LSP subsection that matches the README.
+- Put plugins dedicated to Markdown language-server support in `documentation.md / Documentation / Markdown / LSP`, not generic LSP setup or pre-configuration sections.
 
 ## Exclusions
 


### PR DESCRIPTION
Updates `.codex/skills/add/**` from reviewed correction feedback.

Source branch: `ai-28209339106`
Source commit: `031a2187dedd6afe13cd39b34c785b34a8a0adc4`
Source PR: 3034
Trigger commit message:

```
teach: categorize Markdown LSP plugins as documentation

Correction:
- RaquerLabs/xsmd.nvim: lsp.md / Pre-configuration -> documentation.md / Documentation / Markdown / LSP

Reusable lesson:
- Plugins dedicated to Markdown language-server support belong under Documentation / Markdown / LSP, not generic LSP setup or pre-configuration sections.

Evidence:
- Worktree diff in documentation.md and lsp.md
```
